### PR TITLE
Reactions (posts/comments) + profile tests: clarify auth and stabiliz…

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,13 +1,41 @@
 class CommentsController < ApplicationController
-  before_action :set_post
+  before_action :set_post,    only: :create
+  before_action :set_comment, only: %i[update destroy]
 
   def create
-    @post.comments.create! params.expect(comment: [ :content ])
-    redirect_to @post
-  end
-  
-  private
-    def set_post
-        @post = Post.find(params[:post_id])
+    @comment = @post.comments.build(comment_params)
+    if @comment.save
+      redirect_to @post, notice: "Comment created"
+    else
+      redirect_to @post, alert: @comment.errors.full_messages.to_sentence
     end
+  end
+
+  def update
+    if @comment.update(comment_params)
+      redirect_to @comment.post, notice: "Comment updated"
+    else
+      redirect_to @comment.post, alert: @comment.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    post = @comment.post
+    @comment.destroy
+    redirect_to post, notice: "Comment deleted"
+  end
+
+  private
+
+  def set_post
+    @post = Post.find(params[:post_id])
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
 end

--- a/app/models/profile_user.rb
+++ b/app/models/profile_user.rb
@@ -1,4 +1,5 @@
 class ProfileUser < ApplicationRecord
   belongs_to :user, inverse_of: :profile_user
   validates :full_name, length: { maximum: 255 }, allow_blank: true
+  validates :user_id, uniqueness: true
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,13 +14,12 @@
 
 <h3>Reactions</h3>
 <% Reaction::KINDS.each do |k| %>
-  <%= button_to "React: #{k}",
-        post_reactions_path(@post, kind: k),
-        method: :post %>
-
-  <%= button_to "Unreact: #{k}",
-        post_reactions_path(@post, kind: k),
-        method: :delete %>
+  <% existing = @post.reactions.exists?(user: current_user, kind: k) %>
+  <% if existing %>
+    <%= button_to "Unreact: #{k}", post_reactions_path(@post, kind: k), method: :delete %>
+  <% else %>
+    <%= button_to "React: #{k}", post_reactions_path(@post, kind: k), method: :post %>
+  <% end %>
 <% end %>
 
 <p>Total reactions: <%= @post.reactions.count %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :comments, only: [:update, :destroy]
+
   resource :profile, only: %i[show edit update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/comments/reactions_controller_test.rb
+++ b/test/controllers/comments/reactions_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Comments::ReactionsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+    @post_record = Post.create!(title: "Hello", body: "World")
+    @comment = Comment.create!(content: "Nice!", post: @post_record)
+  end
+
+  test "requires login for create" do
+    assert_no_difference "Reaction.count" do
+      post comment_reactions_path(@comment), params: { kind: "like" }
+    end
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "requires login for destroy" do
+    Reaction.create!(user: @user, reactable: @comment, kind: "like")
+    assert_no_difference "Reaction.count" do
+      delete comment_reactions_path(@comment), params: { kind: "like" }
+    end
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "creates reaction when logged in" do
+    log_in(@user)
+    assert_difference "Reaction.count", +1 do
+      post comment_reactions_path(@comment), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "is idempotent on create with same kind" do
+    log_in(@user)
+    post comment_reactions_path(@comment), params: { kind: "like" }
+    assert_no_difference "Reaction.count" do
+      post comment_reactions_path(@comment), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "destroys reaction by kind when logged in" do
+    log_in(@user)
+    Reaction.create!(user: @user, reactable: @comment, kind: "like")
+    assert_difference "Reaction.count", -1 do
+      delete comment_reactions_path(@comment), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "does not create with invalid kind" do
+    log_in(@user)
+    assert_no_difference "Reaction.count" do
+      post comment_reactions_path(@comment), params: { kind: "angry" }
+    end
+    assert_response :redirect
+  end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,7 +1,34 @@
 require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @post_record = Post.create!(title: "Hello", body: "World")
+  end
+
+  test "creates comment (nested under post) without login" do
+    assert_difference "Comment.count", +1 do
+      post post_comments_path(@post_record), params: { comment: { content: "Nice!" } }
+    end
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+  end
+
+  test "updates comment by id (top-level route) without login" do
+    comment = Comment.create!(content: "Old", post: @post_record)
+
+    patch comment_path(comment), params: { comment: { content: "New" } }
+    assert_response :redirect
+    comment.reload
+    assert_equal "New", comment.content
+  end
+
+  test "destroys comment by id (top-level route) without login" do
+    comment = Comment.create!(content: "To be deleted", post: @post_record)
+
+    assert_difference "Comment.count", -1 do
+      delete comment_path(comment)
+    end
+    assert_response :redirect
+  end
 end

--- a/test/controllers/posts/reactions_controller_test.rb
+++ b/test/controllers/posts/reactions_controller_test.rb
@@ -1,0 +1,64 @@
+# test/controllers/posts/reactions_controller_test.rb
+require "test_helper"
+
+class Posts::ReactionsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+    @post_record = Post.create!(title: "Hello", body: "World")
+  end
+
+  test "requires login for create" do
+    assert_no_difference "Reaction.count" do
+      post post_reactions_path(@post_record), params: { kind: "like" }
+    end
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "requires login for destroy" do
+    Reaction.create!(user: @user, reactable: @post_record, kind: "like")
+    assert_no_difference "Reaction.count" do
+      delete post_reactions_path(@post_record), params: { kind: "like" }
+    end
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "creates reaction when logged in" do
+    log_in(@user)
+    assert_difference "Reaction.count", +1 do
+      post post_reactions_path(@post_record), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "is idempotent on create with same kind" do
+    log_in(@user)
+    post post_reactions_path(@post_record), params: { kind: "like" }
+    assert_no_difference "Reaction.count" do
+      post post_reactions_path(@post_record), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "destroys reaction by kind when logged in" do
+    log_in(@user)
+    Reaction.create!(user: @user, reactable: @post_record, kind: "like")
+    assert_difference "Reaction.count", -1 do
+      delete post_reactions_path(@post_record), params: { kind: "like" }
+    end
+    assert_response :redirect
+  end
+
+  test "does not create with invalid kind" do
+    log_in(@user)
+    assert_no_difference "Reaction.count" do
+      post post_reactions_path(@post_record), params: { kind: "angry" }
+    end
+    assert_response :redirect
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PostsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @post = posts(:one)
+    @post = Post.create!(title: "Hello", body: "World")
   end
 
   test "should get index" do
@@ -17,9 +17,8 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create post" do
     assert_difference("Post.count") do
-      post posts_url, params: { post: { body: @post.body, title: @post.title } }
+      post posts_url, params: { post: { body: "New body", title: "New title" } }
     end
-
     assert_redirected_to post_url(Post.last)
   end
 
@@ -34,7 +33,7 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update post" do
-    patch post_url(@post), params: { post: { body: @post.body, title: @post.title } }
+    patch post_url(@post), params: { post: { body: "Updated", title: "Updated" } }
     assert_redirected_to post_url(@post)
   end
 
@@ -42,7 +41,6 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_difference("Post.count", -1) do
       delete post_url(@post)
     end
-
     assert_redirected_to posts_url
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+    # after_create callback harus sudah bikin profile_user
+    @profile = @user.profile_user
+  end
+
+  test "requires login for show" do
+    get profile_url
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "requires login for edit" do
+    get edit_profile_url
+    assert_response :redirect
+    assert_match(/sign_in/, @response.redirect_url)
+  end
+
+  test "shows profile when logged in" do
+    sign_in @user
+    get profile_url
+    assert_response :success
+  end
+
+  test "edits profile when logged in" do
+    sign_in @user
+    get edit_profile_url
+    assert_response :success
+  end
+
+  test "updates profile when logged in" do
+    sign_in @user
+    patch profile_url, params: {
+      profile_user: {
+        full_name: "John Doe",
+        address:   "Jl. Mawar 123"
+      }
+    }
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+
+    @profile.reload
+    assert_equal "John Doe", @profile.full_name
+    assert_equal "Jl. Mawar 123", @profile.address
+  end
+
+  test "auto builds profile if missing on first edit/update" do
+    # Simulasikan user lama tanpa profile (kalau perlu)
+    @profile.destroy
+    @user.reload
+    assert_nil @user.profile_user
+
+    sign_in @user
+    patch profile_url, params: { profile_user: { full_name: "Baru", address: "Alamat" } }
+    assert_response :redirect
+
+    @user.reload
+    assert @user.profile_user.present?
+    assert_equal "Baru",   @user.profile_user.full_name
+    assert_equal "Alamat", @user.profile_user.address
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,7 +1,32 @@
 require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_post
+    Post.create!(title: "Hello", body: "World")
+  end
+
+  test "is valid with content and post" do
+    post = build_post
+    comment = Comment.new(content: "Nice post!", post: post)
+    assert comment.valid?
+  end
+
+  test "is invalid without post" do
+    comment = Comment.new(content: "No post attached")
+    assert_not comment.valid?
+    assert_includes comment.errors[:post], "must exist"
+  end
+
+  test "can have reactions" do
+    post = build_post
+    comment = Comment.create!(content: "Hello!", post: post)
+    user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+
+    reaction = Reaction.create!(user: user, reactable: comment, kind: "like")
+    assert_includes comment.reactions, reaction
+  end
 end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,7 +1,44 @@
 require "test_helper"
 
 class PostTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_post(attrs = {})
+    defaults = { title: "Hello", body: "World" }
+    Post.create!(defaults.merge(attrs))
+  end
+
+  test "is valid with title and body" do
+    post = build_post
+    assert post.valid?
+  end
+
+  test "can have comments" do
+    post = build_post
+    comment = Comment.create!(content: "Nice!", post: post)
+    assert_includes post.comments, comment
+  end
+
+  test "can have reactions (polymorphic)" do
+    post = build_post
+    user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+
+    reaction = Reaction.create!(user: user, reactable: post, kind: "like")
+    assert_includes post.reactions, reaction
+  end
+
+  test "reactions of different kinds can coexist on same post" do
+    post = build_post
+    user = User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+
+    Reaction.create!(user: user, reactable: post, kind: "like")
+    another = Reaction.new(user: user, reactable: post, kind: "love")
+    assert another.valid?
+  end
 end

--- a/test/models/profile_user_test.rb
+++ b/test/models/profile_user_test.rb
@@ -1,7 +1,58 @@
 require "test_helper"
 
 class ProfileUserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_user
+    User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+  end
+
+  test "auto creates profile for new user (after_create callback)" do
+    user = build_user
+    assert user.profile_user.present?, "expected user.profile_user to be created automatically"
+  end
+
+  test "profile belongs to user (must exist)" do
+    user = build_user
+    profile = user.profile_user
+    assert profile.valid?
+    assert_equal user.id, profile.user_id
+  end
+
+  test "only one profile per user (uniqueness)" do
+    user = build_user
+    profile = user.profile_user
+    duplicate = ProfileUser.new(user: user)
+
+    assert_not duplicate.valid?, "expected duplicate profile to be invalid"
+    assert_includes duplicate.errors[:user_id], "has already been taken"
+  end
+
+  test "full_name max length 255" do
+    user = build_user
+    p = user.profile_user
+    p.full_name = "a" * 255
+    assert p.valid?, "255 chars should be valid"
+
+    p.full_name = "a" * 256
+    assert_not p.valid?, "256 chars should be invalid"
+    assert_includes p.errors[:full_name], "is too long (maximum is 255 characters)"
+  end
+
+  test "address and full_name can be blank" do
+    user = build_user
+    p = user.profile_user
+    p.full_name = ""
+    p.address   = ""
+    assert p.valid?
+  end
+
+  test "destroying user destroys profile (dependent destroy / FK cascade)" do
+    user = build_user
+    profile_id = user.profile_user.id
+    user.destroy
+    assert_not ProfileUser.exists?(profile_id), "profile should be removed when user is destroyed"
+  end
 end

--- a/test/models/reaction_test.rb
+++ b/test/models/reaction_test.rb
@@ -1,7 +1,63 @@
 require "test_helper"
 
 class ReactionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_user
+    User.create!(
+      email: "user-#{SecureRandom.hex(6)}@example.com",
+      password: "password",
+      confirmed_at: Time.current
+    )
+  end
+
+  def build_post
+    Post.create!(title: "Hello", body: "World")
+  end
+
+  test "valid reaction with kind" do
+    user = build_user
+    post = build_post
+    reaction = Reaction.new(user: user, reactable: post, kind: "like")
+    assert reaction.valid?
+  end
+
+  test "invalid reaction with unsupported kind" do
+    user = build_user
+    post = build_post
+    reaction = Reaction.new(user: user, reactable: post, kind: "angry")
+    assert_not reaction.valid?
+    assert_includes reaction.errors[:kind], "is not included in the list"
+  end
+
+  test "allows nil kind" do
+    user = build_user
+    post = build_post
+    reaction = Reaction.new(user: user, reactable: post, kind: nil)
+    assert reaction.valid?
+  end
+
+  test "prevents duplicate reaction per user/reactable/kind" do
+    user = build_user
+    post = build_post
+    Reaction.create!(user: user, reactable: post, kind: "like")
+    duplicate = Reaction.new(user: user, reactable: post, kind: "like")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:user_id], "has reacted to this item"
+  end
+
+  test "allows same kind on different reactables" do
+    user = build_user
+    post = build_post
+    comment = Comment.create!(content: "Nice!", post: post)  # ← tanpa user
+    Reaction.create!(user: user, reactable: post, kind: "like")
+    other = Reaction.new(user: user, reactable: comment, kind: "like")
+    assert other.valid?
+  end
+
+  test "allows different kinds on the same reactable" do
+    user = build_user
+    post = build_post
+    Reaction.create!(user: user, reactable: post, kind: "like")
+    other = Reaction.new(user: user, reactable: post, kind: "love")
+    assert other.valid?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,56 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def build_email
+    "user-#{SecureRandom.hex(6)}@example.com"
+  end
+
+  def auth_hash(provider: "google_oauth2", uid: SecureRandom.hex(8), email: build_email)
+    OmniAuth::AuthHash.new(
+      provider: provider,
+      uid: uid,
+      info: OmniAuth::AuthHash::InfoHash.new(email: email)
+    )
+  end
+
+  test "is valid with email and password" do
+    user = User.new(email: build_email, password: "password", confirmed_at: Time.current)
+    assert user.valid?, "expected user to be valid with email/password"
+    assert user.save
+  end
+
+  test "email must be unique" do
+    email = build_email
+    User.create!(email: email, password: "password", confirmed_at: Time.current)
+
+    dup = User.new(email: email, password: "password", confirmed_at: Time.current)
+    assert_not dup.valid?, "duplicate email should be invalid"
+    assert_includes dup.errors[:email], "has already been taken"
+  end
+
+  test "creates profile_user after create" do
+    user = User.create!(email: build_email, password: "password", confirmed_at: Time.current)
+    assert user.profile_user.present?, "expected profile_user to be auto-created"
+  end
+
+  test ".from_omniauth creates a new user with email and confirmed_at" do
+    auth = auth_hash
+    user = User.from_omniauth(auth)
+
+    assert user.persisted?, "from_omniauth should persist user"
+    assert_equal auth.info.email, user.email
+    assert user.confirmed_at.present?, "from_omniauth should set confirmed_at"
+  end
+
+  test ".from_omniauth is idempotent for same provider+uid" do
+    uid = SecureRandom.hex(8)
+    email = build_email
+    auth1 = auth_hash(uid: uid, email: email)
+    user1 = User.from_omniauth(auth1)
+
+    auth2 = auth_hash(uid: uid, email: email)
+    user2 = User.from_omniauth(auth2)
+
+    assert_equal user1.id, user2.id, "should return existing user for same provider+uid"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,8 +8,20 @@ module ActiveSupport
     parallelize(workers: :number_of_processors)
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-    fixtures :all
+    # fixtures :all
 
     # Add more helper methods to be used by all tests here...
+  end
+
+  class ActionDispatch::IntegrationTest
+    include Devise::Test::IntegrationHelpers
+
+    def log_in(user, password: "password")
+      post user_session_path, params: {
+        user: { email: user.email, password: password }
+      }
+      follow_redirect! if response.redirect?
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
Reactions (posts/comments) + profile tests: clarify auth and stabilize integration tests

WHY
- Users can react to posts/comments; we need server-side guarantees (idempotency, kind validation) and regression coverage.
- Previous integration tests flaked due to Devise mapping in namespaced tests.

WHAT
- Add polymorphic Reaction model and routes for posts/comments.
- CommentsController: split nested create vs top-level update/destroy, consistent redirects.
- ProfilesController: auto-build profile_user for existing users without profile.
- Test suite: model tests (Reaction, Comment, Post, ProfileUser, User) + controller tests for comments, profiles, reactions.
- Add HTTP login helper (log_in) for stable Devise auth in IntegrationTest.

RESULT
- All tests passing locally (52 runs, 0 failures).
- Safer reaction semantics (idempotent create, destroy by kind).
- Clearer routing for comments; profile update covered.